### PR TITLE
Adds Flame, Flame Assist and Flare to the default config.

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -1,23 +1,23 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 #
 # This file is one of the central points in the Shotgun Pipeline Toolkit configuration and
 # a counterpart to the folder configuration structure.
 #
-# The folder structure underneath the project folder is used to create folders on disk - 
-# templates.yml (this file) refers to those folders. Therefore, the two files need to be 
+# The folder structure underneath the project folder is used to create folders on disk -
+# templates.yml (this file) refers to those folders. Therefore, the two files need to be
 # in sync. This file contains an overview of all locations that are used by Sgtk.
 #
-# Whenever an app or an engine refers to a location on disk, it is using an entry defined in 
-# this file. For more information, see the Shotgun Pipeline Toolkit Documentation. 
+# Whenever an app or an engine refers to a location on disk, it is using an entry defined in
+# this file. For more information, see the Shotgun Pipeline Toolkit Documentation.
 
 
 
@@ -55,12 +55,14 @@ keys:
         type: int
     height:
         type: int
-        
+    segment_name:
+        type: str
+
     # Represents the optional output name for frames written by the Shotgun Write Node
     output:
         type: str
         filter_by: alphanumeric
-        
+
     SEQ:
         type: sequence
         format_spec: "04"
@@ -68,7 +70,7 @@ keys:
         type: str
     node:
         type: str
-    
+
     # these are used by the hiero exporter and pipeline
     YYYY:
         type: int
@@ -82,8 +84,8 @@ keys:
         alias: DD
     project:
         type: str
-        
-    # These are used for the Mari UDIM pipeline:        
+
+    # These are used for the Mari UDIM pipeline:
     UDIM:
         type: sequence
         default: "<UDIM>"
@@ -91,7 +93,7 @@ keys:
         type: str
     layer:
         type: str
-        
+
     mari_project_name:
         type: str
         alias: name
@@ -102,7 +104,7 @@ keys:
     task_name:
         type: str
         shotgun_entity_type: Task
-        shotgun_field_name: content 
+        shotgun_field_name: content
 
 
 
@@ -123,7 +125,7 @@ paths:
     sequence_root: sequences/{Sequence}
 
     ##########################################################################################
-    # Project level paths 
+    # Project level paths
     #
 
     #
@@ -141,14 +143,19 @@ paths:
     hiero_project_publish: 'editorial/publish/{name}_v{version}.hrox'
     hiero_project_publish_area: 'editorial/publish'
 
-    
+
     ##########################################################################################
-    # Sequence level paths 
+    # Sequence level paths
     #
 
+    flame_segment_clip: 'sequences/{Sequence}/{Shot}/editorial/flame/sources/{segment_name}.clip'
+    flame_shot_clip:    'sequences/{Sequence}/{Shot}/editorial/flame/{Shot}.clip'
+    flame_shot_batch:   'sequences/{Sequence}/{Shot}/editorial/flame/batch/{Shot}.v{version}.batch'
+    flame_shot_plate_dpx:   'sequences/{Sequence}/{Shot}/editorial/dpx_plates/v{version}/{segment_name}/{segment_name}_{Shot}.v{version}.{SEQ}.dpx'
+    flame_shot_plate_exr:   'sequences/{Sequence}/{Shot}/editorial/exr_plates/v{version}/{segment_name}/{segment_name}_{Shot}.v{version}.{SEQ}.exr'
 
     ##########################################################################################
-    # Shot level paths 
+    # Shot level paths
     #
 
     #
@@ -172,7 +179,7 @@ paths:
 
     # define the location of a work area
     shot_work_area_maya: '@shot_root/work/maya'
-    
+
     # define the location of a publish area
     shot_publish_area_maya: '@shot_root/publish/maya'
 
@@ -218,7 +225,7 @@ paths:
 
     # define the location of a work area
     shot_work_area_max: '@shot_root/work/3dsmax'
-    
+
     # define the location of a publish area
     shot_publish_area_max: '@shot_root/publish/3dsmax'
 
@@ -252,12 +259,12 @@ paths:
     mobu_shot_publish: '@shot_root/publish/mobu/{name}.v{version}.fbx'
 
     #
-    # Nuke 
+    # Nuke
     #
 
     # define the location of a work area
     shot_work_area_nuke: '@shot_root/work/nuke'
-    
+
     # define the location of a publish area
     shot_publish_area_nuke: '@shot_root/publish/nuke'
 
@@ -295,7 +302,7 @@ paths:
 
     # define the location of a work area
     shot_work_area_softimage: '@shot_root/work/softimage'
-    
+
     # define the location of a publish area
     shot_publish_area_softimage: '@shot_root/publish/softimage'
 
@@ -310,14 +317,14 @@ paths:
 
 
     ##########################################################################################
-    # Asset pipeline 
-    
+    # Asset pipeline
+
     #
     # Alembic caches
     #
-    
+
     asset_alembic_cache: '@asset_root/publish/caches/{name}.v{version}.abc'
-    
+
     #
     # Photoshop
     #
@@ -332,21 +339,21 @@ paths:
     # The location of published files
     asset_publish_area_photoshop: '@asset_root/publish/photoshop'
     photoshop_asset_publish: '@asset_root/publish/photoshop/{name}.v{version}.psd'
-    
+
     #
     # Mari
     #
-    
+
     asset_mari_texture_tif: '@asset_root/publish/mari/{name}_{channel}[_{layer}].v{version}.{UDIM}.tif'
-    
-    
+
+
     #
     # Maya
     #
-    
+
     # define the location of a work area
     asset_work_area_maya: '@asset_root/work/maya'
-    
+
     # define the location of a publish area
     asset_publish_area_maya: '@asset_root/publish/maya'
 
@@ -389,13 +396,13 @@ paths:
     #
     # 3dsmax
     #
-    
+
     # define the location of a work area
     asset_work_area_max: '@asset_root/work/3dsmax'
-    
+
     # define the location of a publish area
     asset_publish_area_max: '@asset_root/publish/3dsmax'
-    
+
     # The location of WIP files
     max_asset_work: '@asset_root/work/3dsmax/{name}.v{version}.max'
 
@@ -430,7 +437,7 @@ paths:
 
     # define the location of a work area
     asset_work_area_nuke: '@asset_root/work/nuke'
-    
+
     # define the location of a publish area
     asset_publish_area_nuke: '@asset_root/publish'
 
@@ -457,7 +464,7 @@ paths:
 
     # define the location of a work area
     asset_work_area_softimage: '@asset_root/work/softimage'
-    
+
     # define the location of a publish area
     asset_publish_area_softimage: '@asset_root/publish/softimage'
 
@@ -473,14 +480,14 @@ paths:
 
 #
 # The strings section is similar to the paths section - but rather than defining paths
-# on disk, it contains a list of strings. Strings are typically used when you want to be 
+# on disk, it contains a list of strings. Strings are typically used when you want to be
 # able to configure the way data is written to shotgun - it may be the name field for a
 # review version or the formatting of a publish.
 #
 
 strings:
 
-    # when a review version in shotgun is created inside of nuke, this is the 
+    # when a review version in shotgun is created inside of nuke, this is the
     # name that is being given to it (the code field)
     nuke_shot_version_name: "{Shot}_{name}_{output}_v{version}.{iteration}"
     nuke_quick_shot_version_name: "{Shot}_{name}_quick_{iteration}"
@@ -493,4 +500,3 @@ strings:
 
     # define how new Mari projects should be named
     mari_asset_project_name: "{mari_project_name} - Asset {asset_name}, {task_name}"
-    

--- a/env/includes/paths.yml
+++ b/env/includes/paths.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 #
 
@@ -61,12 +61,11 @@ houdini_linux: '/opt/hfs13.0.498/bin/houdini'
 #
 photoshop_mac: /Applications/Adobe Photoshop CS6/Adobe Photoshop CS6.app
 photoshop_win: 'C:\Program Files\Adobe\Adobe Photoshop CS6 (64 Bit)\Photoshop.exe'
-photoshop_extras:         
+photoshop_extras:
     mac_extension_manager_path: /Applications/Adobe Extension Manager CS6/Adobe Extension Manager CS6.app
     mac_python_path: /usr/bin/python
     windows_extension_manager_path: 'C:\Program Files (x86)\Adobe\Adobe Extension Manager CS6\XManCommand.exe'
     windows_python_path: 'C:\Python27\python.exe'
-
 
 #
 # Hiero
@@ -74,6 +73,24 @@ photoshop_extras:
 hiero_mac: /Applications/Hiero1.8v2/Hiero1.8v2.app
 hiero_win: C:\Program Files\The Foundry\Hiero1.8v2\hiero.exe
 hiero_linux: /usr/local/Hiero1.8v2/bin/Hiero1.8v2
+
+#
+# Flame
+#
+flame_linux: /usr/discreet/flame_2015.2/bin/startApplication
+
+#
+# Flame Assist
+#
+flame_assist_mac: /usr/discreet/flameassist_2015.2/bin/startApplication
+flame_assist_linux: /usr/discreet/flameassist_2015.2/bin/startApplication
+
+#
+# Flare
+#
+flare_mac: /usr/discreet/flare_2015.2/bin/startApplication
+flare_linux: /usr/discreet/flare_2015.2/bin/startApplication
+
 
 #
 # Softimage
@@ -88,4 +105,3 @@ softimage_linux: XSI
 rv_mac: /Applications/RV64.app
 rv_win: C:\Program Files\RV\RV64.exe
 rv_linux: rv
-

--- a/env/project.yml
+++ b/env/project.yml
@@ -24,34 +24,73 @@ engines:
 
   tk-3dsmax:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location: {name: tk-3dsmax, type: app_store, version: v0.3.2}
-    
+
   tk-desktop:
     apps:
-      tk-multi-launch3dsmax: '@launch_3dsmax'
-      tk-multi-launchhiero: '@launch_hiero'
-      tk-multi-launchmari: '@launch_mari'
-      tk-multi-launchmaya: '@launch_maya'
-      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
-      tk-multi-launchnuke: '@launch_nuke'
-      tk-multi-launchphotoshop: '@launch_photoshop'
-      tk-multi-launchsoftimage: '@launch_softimage'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-launch3dsmax: '@launch_3dsmax'
+        tk-multi-launchflame: '@launch_flame'
+        tk-multi-launchflameassist: '@launch_flame_assist'        
+        tk-multi-launchhiero: '@launch_hiero'
+        tk-multi-launchmari: '@launch_mari'
+        tk-multi-launchmaya: '@launch_maya'
+        tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+        tk-multi-launchnuke: '@launch_nuke'
+        tk-multi-launchphotoshop: '@launch_photoshop'
+        tk-multi-launchsoftimage: '@launch_softimage'
+        tk-multi-screeningroom: '@launch_screeningroom'
     collapse_rules:
     - {button_label: $app, match: Launch $app, menu_label: None}
     debug_logging: false
     default_group: Studio
     groups:
-    - matches: ['*Hiero*', '*Houdini*', '*Mari*', '*Max*', '*Maya*', '*Motion*', '*Nuke*', '*Photoshop*', '*Softimage*']
+    - matches: ['*Houdini*', '*Mari*', '*Max*', '*Maya*', '*Motion*', '*Nuke*', '*Photoshop*', '*Softimage*']
       name: Creative Tools
+    - matches: ['*Fla*', '*Hiero*']
+      name: Editorial Tools
     hook_launch_python: default
     location: {name: tk-desktop, type: app_store, version: v1.0.2}
     show_recents: true
-    
+
+
+  tk-flame:
+    apps:
+      tk-flame-review:
+        location: {name: tk-flame-review, type: app_store, version: v0.3.3}
+        task_template: ""
+        shotgun_entity_type: Sequence
+        menu_name: Submit for Shotgun review
+        settings_hook: '{self}/settings.py'
+      tk-flame-export:
+        location: {name: tk-flame-export, type: app_store, version: v0.3.0}
+        shot_parent_entity_type: Sequence
+        shot_parent_link_field: sg_sequence
+        shot_parent_task_template: ""
+        task_template: "Basic shot template"
+        menu_name: Shotgun Shot Export
+        settings_hook: '{self}/settings.py'
+        plate_presets:
+        - template: flame_shot_plate_dpx
+          publish_type: Flame Plate
+          name: 10 bit DPX
+        - template: flame_shot_plate_exr
+          publish_type: Flame Plate
+          name: 12 bit OpenEXR        
+        shot_clip_template: flame_shot_clip
+        segment_clip_template: flame_segment_clip
+        batch_template: flame_shot_batch
+        clip_publish_type: Flame Open Clip
+        batch_publish_type: Flame Batch File
+    debug_logging: true
+    location: {name: tk-flame, type: app_store, version: v0.6.0}
+    project_startup_hook: '{self}/project_startup.py'
+    flame_batch_publish_type: Flame Batch File
+    backburner_shared_tmp: '/tmp'
+
   tk-hiero:
     apps:
       tk-hiero-export:
@@ -146,7 +185,7 @@ engines:
     timeline_context_menu:
     - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
       requires_selection: true}
-      
+
   tk-mari:
     apps:
       tk-multi-about: '@about'
@@ -172,12 +211,12 @@ engines:
         template_work_area: null
     debug_logging: false
     location: {name: tk-mari, type: app_store, version: v1.0.0}
-    
+
   tk-maya:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles-launch-at-startup'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles-launch-at-startup'
     compatibility_dialog_min_version: 2015
     debug_logging: false
     location: {name: tk-maya, type: app_store, version: v0.4.2}
@@ -185,24 +224,24 @@ engines:
     - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
     template_project: null
     use_sgtk_as_menu_name: false
-    
+
   tk-motionbuilder:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location: {name: tk-motionbuilder, type: app_store, version: v0.3.0}
     menu_favourites:
     - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
     template_project: null
     use_sgtk_as_menu_name: false
-    
+
   tk-nuke:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
     compatibility_dialog_min_version: 9
     debug_logging: false
     favourite_directories: []
@@ -211,19 +250,21 @@ engines:
     - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
     project_favourite_name: Shotgun Current Project
     use_sgtk_as_menu_name: false
-    
+
   tk-photoshop:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location: {name: tk-photoshop, type: app_store, version: v0.2.0}
-    
+
   tk-shell:
     apps:
       tk-multi-launch3dsmax: '@launch_3dsmax'
       tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflameassist: '@launch_flame_assist'
       tk-multi-launchmari: '@launch_mari'
       tk-multi-launchmaya: '@launch_maya'
       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
@@ -232,18 +273,18 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
     location: {name: tk-shell, type: app_store, version: v0.4.0}
-    
+
   tk-softimage:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
     debug_logging: false
     location: {name: tk-softimage, type: app_store, version: v0.3.0}
     menu_favourites:
     - {app_instance: tk-multi-workfiles, name: Shotgun File Manager...}
     template_project: null
-    
+
 frameworks:
   tk-framework-adminui_v0.x.x:
     location: {name: tk-framework-adminui, type: app_store, version: v0.0.7}

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -29,17 +29,17 @@ engines:
 
   tk-3dsmax:
     apps:
-      tk-multi-workfiles: '@workfiles'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     debug_logging: false
     location: {name: tk-3dsmax, type: app_store, version: v0.3.2}
 
   tk-maya:
     apps:
-      tk-multi-workfiles: '@workfiles-launch-at-startup'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles-launch-at-startup'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     compatibility_dialog_min_version: 2015
     debug_logging: false
     location: {name: tk-maya, type: app_store, version: v0.4.2}
@@ -50,9 +50,9 @@ engines:
 
   tk-motionbuilder:
     apps:
-      tk-multi-workfiles: '@workfiles'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     debug_logging: false
     location: {name: tk-motionbuilder, type: app_store, version: v0.3.0}
     menu_favourites:
@@ -61,9 +61,9 @@ engines:
 
   tk-nuke:
     apps:
-      tk-multi-workfiles: '@workfiles'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     compatibility_dialog_min_version: 9
     debug_logging: false
     favourite_directories: []
@@ -75,28 +75,63 @@ engines:
 
   tk-photoshop:
     apps:
-      tk-multi-workfiles: '@workfiles'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     debug_logging: false
     location: {name: tk-photoshop, type: app_store, version: v0.2.0}
 
+  tk-flare:
+    apps:
+      tk-flame-review:
+        location: {name: tk-flame-review, type: app_store, version: v0.3.3}
+        task_template: ""
+        shotgun_entity_type: Sequence
+        menu_name: Submit for Shotgun review
+        settings_hook: '{self}/settings.py'
+      tk-flame-export:
+        location: {name: tk-flame-export, type: app_store, version: v0.3.0}
+        shot_parent_entity_type: Sequence
+        shot_parent_link_field: sg_sequence
+        shot_parent_task_template: ""
+        task_template: "Basic shot template"
+        menu_name: Shotgun Shot Export
+        settings_hook: '{self}/settings.py'
+        plate_presets:
+        - template: flame_shot_plate_dpx
+          publish_type: Flame Plate
+          name: 10 bit DPX
+        - template: flame_shot_plate_exr
+          publish_type: Flame Plate
+          name: 12 bit OpenEXR        
+        shot_clip_template: flame_shot_clip
+        segment_clip_template: flame_segment_clip
+        batch_template: flame_shot_batch
+        clip_publish_type: Flame Open Clip
+        batch_publish_type: Flame Batch File
+    debug_logging: true
+    location: {name: tk-flame, type: app_store, version: v0.6.0}
+    project_startup_hook: '{self}/project_startup.py'
+    flame_batch_publish_type: Flame Batch File
+    backburner_shared_tmp: '/tmp'
+
   tk-shell:
     apps:
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-launch3dsmax: '@launch_3dsmax'
-      tk-multi-launchmaya: '@launch_maya'
-      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
-      tk-multi-launchnuke: '@launch_nuke'
-      tk-multi-launchphotoshop: '@launch_photoshop'
-      tk-multi-launchsoftimage: '@launch_softimage'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-launch3dsmax: '@launch_3dsmax'
+        tk-multi-launchmaya: '@launch_maya'
+        tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+        tk-multi-launchnuke: '@launch_nuke'
+        tk-multi-launchflare: '@launch_flare'
+        tk-multi-launchphotoshop: '@launch_photoshop'
+        tk-multi-launchsoftimage: '@launch_softimage'
     location: {name: tk-shell, type: app_store, version: v0.4.0}
 
   tk-softimage:
     apps:
-      tk-multi-workfiles: '@workfiles'
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-workfiles: '@workfiles'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
     debug_logging: false
     location: {name: tk-softimage, type: app_store, version: v0.3.0}
     menu_favourites:

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 #
 
@@ -77,7 +77,7 @@ engines:
       tk-multi-setframerange:
         location: {name: tk-multi-setframerange, type: app_store, version: v0.2.2}
         sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out      
+        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
         hook_copy_file: default
         hook_scene_operation: default
@@ -107,7 +107,7 @@ engines:
         template_work_area: shot_work_area_max
     debug_logging: false
     location: {name: tk-3dsmax, type: app_store, version: v0.3.2}
-    
+
   tk-houdini:
     apps:
       tk-multi-about: '@about'
@@ -171,7 +171,7 @@ engines:
     - {app_instance: tk-multi-snapshot, name: Snapshot...}
     - {app_instance: tk-multi-workfiles, name: Shotgun Save As...}
     - {app_instance: tk-multi-publish, name: Publish...}
-    
+
   tk-maya:
     apps:
       tk-maya-breakdown:
@@ -271,7 +271,7 @@ engines:
     - {app_instance: tk-multi-publish, name: Publish...}
     template_project: shot_work_area_maya
     use_sgtk_as_menu_name: false
-    
+
   tk-motionbuilder:
     apps:
       tk-multi-about: '@about'
@@ -368,7 +368,7 @@ engines:
     - {app_instance: tk-multi-workfiles, name: Shotgun Save As...}
     - {app_instance: tk-multi-publish, name: Publish...}
     use_sgtk_as_menu_name: false
-    
+
   tk-nuke:
     apps:
       tk-multi-about: '@about'
@@ -376,6 +376,7 @@ engines:
         action_mappings:
           Nuke Script: [script_import]
           Rendered Image: [read_node]
+          Flame Plate: [read_node]
         actions_hook: '{self}/tk-nuke_actions.py'
         download_thumbnails: true
         entities:
@@ -525,7 +526,7 @@ engines:
     - {app_instance: tk-multi-publish, name: Publish...}
     project_favourite_name: Shotgun Current Project
     use_sgtk_as_menu_name: false
-    
+
   tk-photoshop:
     apps:
       tk-multi-about: '@about'
@@ -580,20 +581,20 @@ engines:
         template_work_area: shot_work_area_photoshop
     debug_logging: false
     location: {name: tk-photoshop, type: app_store, version: v0.2.0}
-    
+
   tk-shell:
     apps:
-      tk-multi-about: '@about'
-      tk-multi-screeningroom: '@launch_screeningroom'
-      tk-multi-launch3dsmax: '@launch_3dsmax'
-      tk-multi-launchhoudini: '@launch_houdini'
-      tk-multi-launchmaya: '@launch_maya'
-      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
-      tk-multi-launchnuke: '@launch_nuke'
-      tk-multi-launchphotoshop: '@launch_photoshop'
-      tk-multi-launchsoftimage: '@launch_softimage'
+        tk-multi-about: '@about'
+        tk-multi-screeningroom: '@launch_screeningroom'
+        tk-multi-launch3dsmax: '@launch_3dsmax'
+        tk-multi-launchhoudini: '@launch_houdini'
+        tk-multi-launchmaya: '@launch_maya'
+        tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+        tk-multi-launchnuke: '@launch_nuke'
+        tk-multi-launchphotoshop: '@launch_photoshop'
+        tk-multi-launchsoftimage: '@launch_softimage'
     location: {name: tk-shell, type: app_store, version: v0.4.0}
-    
+
   tk-softimage:
     apps:
       tk-multi-about: '@about'
@@ -658,7 +659,7 @@ engines:
     - {app_instance: tk-multi-workfiles, name: Shotgun Save As...}
     - {app_instance: tk-multi-publish, name: Publish...}
     template_project: shot_work_area_softimage
-    
+
 frameworks:
   tk-framework-shotgunutils_v1.x.x:
     location: {name: tk-framework-shotgunutils, type: app_store, version: v1.0.10}

--- a/env/shotgun_project.yml
+++ b/env/shotgun_project.yml
@@ -28,6 +28,8 @@ engines:
       tk-multi-launch3dsmax: '@launch_3dsmax'
       tk-multi-launchhiero: '@launch_hiero'
       tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflameassist: '@launch_flame_assist'
       tk-multi-launchmaya: '@launch_maya'
       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
       tk-multi-launchnuke: '@launch_nuke'

--- a/env/shotgun_shot.yml
+++ b/env/shotgun_shot.yml
@@ -1,11 +1,11 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 #
 
@@ -19,7 +19,7 @@ include: ./includes/app_launchers.yml
 
 
 #################################################################################################
-# define all the items that should appear in this environment 
+# define all the items that should appear in this environment
 
 engines:
 
@@ -29,6 +29,7 @@ engines:
       tk-multi-launchmaya: '@launch_maya'
       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
       tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchflare: '@launch_flare'
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
@@ -42,5 +43,5 @@ engines:
         location: {name: tk-shotgun-launchfolder, type: app_store, version: v0.1.5}
     debug_logging: false
     location: {name: tk-shotgun, type: app_store, version: v0.5.0}
-    
+
 frameworks: null


### PR DESCRIPTION
This adds Flame, Flame Assist and Flare support to the default config:
- Desktop Launcher for flame and flame assist
- Shotgun Project level access to flame and flame assist
- Shell Project level access to flame and flame assist
- Shotgun Shot level access to flare
- Shell Shot level access to flare
- Added Flame and Flare engine with export and review apps
- Added new templates for flame plates
- Added loader support for flame plates in nuke (shot step context)
