### PR TITLE
#26301: [hiero] way to reset a global cache per-export

### DIFF
--- a/env/project.yml
+++ b/env/project.yml
@@ -65,7 +65,7 @@ engines:
         hook_update_version_data: default
         hook_upload_thumbnail: default
         hook_get_extra_publish_data: default
-        hook_pre_shot_processor: default
+        hook_pre_export: default
         location: {name: tk-hiero-export, type: app_store, version: v0.1.22}
         nuke_script_published_file_type: Nuke Script
         nuke_script_toolkit_write_nodes:


### PR DESCRIPTION
The resolve hook is called tons during an export, so expensive resolve results need to be cached. There currently isn't a hook available that run pre-export where that cache could be cleared
