### PR TITLE
#34913 Make the default config sparse

### DIFF
--- a/env/asset.yml
+++ b/env/asset.yml
@@ -40,7 +40,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -54,13 +53,10 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Houdini
@@ -74,10 +70,6 @@ engines:
       version: v1.0.1
       type: app_store
       name: tk-houdini
-    enable_sg_shelf: true
-    debug_logging: false
-    enable_sg_menu: true
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Mari
@@ -86,32 +78,11 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-workfiles:
-        allow_task_creation: true
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
-        launch_change_work_area_at_startup: false
         location:
           version: v0.7.1
           type: app_store
           name: tk-multi-workfiles
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        sg_entity_type_extra_display_fields: {}
-        sg_entity_type_filters: {}
         sg_entity_types: [Asset]
-        sg_task_filters: []
-        task_extra_display_fields: []
-        template_publish:
-        template_publish_area:
-        template_work:
-        template_work_area:
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2
-    debug_logging: false
     location:
       version: v1.1.4
       type: app_store
@@ -125,17 +96,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2-launch-at-startup'
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
       name: tk-maya
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Motionbuilder
@@ -145,15 +111,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
       name: tk-motionbuilder
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke
@@ -163,20 +126,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
   #
   # -------------------------------------------------
   # Photoshop
@@ -186,7 +141,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.3
       type: app_store
@@ -220,14 +174,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store
       name: tk-softimage
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
 #
 ###############################################################################
 #

--- a/env/asset_step.yml
+++ b/env/asset_step.yml
@@ -35,8 +35,6 @@ engines:
       tk-multi-loader2:
         action_mappings:
           3dsmax Scene: [import]
-        actions_hook: '{self}/tk-3dsmax_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -54,26 +52,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -82,15 +65,10 @@ engines:
         primary_display_name: 3ds Max Publish
         primary_icon: icons/publish_3dsmax_main.png
         primary_publish_template: max_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: 3dsmax Scene
-        secondary_outputs: []
         template_work: max_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -98,40 +76,14 @@ engines:
         template_snapshot: max_asset_snapshot
         template_work: max_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: max_asset_publish
         template_publish_area: asset_publish_area_max
         template_work: max_asset_work
         template_work_area: asset_work_area_max
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -147,8 +99,6 @@ engines:
         action_mappings:
           3dsmax Scene: [import, reference]
           Alembic Cache: [import]
-        actions_hook: '{self}/tk-3dsmaxplus_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -166,26 +116,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -194,15 +129,10 @@ engines:
         primary_display_name: 3ds Max Publish
         primary_icon: icons/publish_3dsmax_main.png
         primary_publish_template: max_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: 3dsmax Scene
-        secondary_outputs: []
         template_work: max_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -210,46 +140,18 @@ engines:
         template_snapshot: max_asset_snapshot
         template_work: max_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: max_asset_publish
         template_publish_area: asset_publish_area_max
         template_work: max_asset_work
         template_work_area: asset_work_area_max
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Houdini
@@ -258,17 +160,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -277,7 +168,6 @@ engines:
         primary_display_name: Scene File Publish
         primary_icon: icons/publish_houdini_main.png
         primary_publish_template: houdini_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Houdini Scene
         secondary_outputs:
         - description: Publish Alembic Cache data for the model
@@ -307,9 +197,6 @@ engines:
         template_work: houdini_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -317,39 +204,14 @@ engines:
         template_snapshot: houdini_asset_snapshot
         template_work: houdini_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: houdini_asset_publish
         template_publish_area: asset_publish_area_houdini
         template_work: houdini_asset_work
         template_work_area: asset_work_area_houdini
-        version_compare_ignore_fields: []
       tk-multi-shotgunpanel:
         location:
           version: v1.2.5
@@ -359,8 +221,6 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py'
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-houdini-alembicnode:
         location:
           version: v0.2.5
@@ -391,8 +251,6 @@ engines:
       tk-multi-loader2:
         action_mappings:
           Alembic Cache: [import]
-        actions_hook: '{self}/tk-houdini_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -410,23 +268,15 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-houdini_scene_operations.py'
         location:
           name: tk-multi-breakdown
           type: app_store
           version: v1.4.3
-    debug_logging: false
-    enable_sg_shelf: true
-    enable_sg_menu: true
     location:
       version: v1.0.1
       type: app_store
@@ -443,27 +293,18 @@ engines:
   tk-mari:
     apps:
       tk-mari-projectmanager:
-        default_project_name: Shotgun
-        get_project_creation_args_hook: '{self}/get_project_creation_args.py'
         location:
           version: v1.2.0
           type: app_store
           name: tk-mari-projectmanager
-        publish_types: [Alembic Cache]
         template_new_project_name: mari_asset_project_name
-        post_project_creation_hook: '{self}/post_project_creation.py'
       tk-multi-about: '@about'
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-mari_scene_operations.py'
         location:
           version: v1.4.3
           type: app_store
           name: tk-multi-breakdown
       tk-multi-loader2:
-        action_mappings:
-          Alembic Cache: [geometry_import]
-        actions_hook: '{self}/tk-mari_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -478,26 +319,13 @@ engines:
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
           publish_filters: []
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
         title_name: Import
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
         expand_single_items: true
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -505,8 +333,6 @@ engines:
         primary_description: Publish items from the current Mari project
         primary_display_name: Mari Publish
         primary_icon: icons/publish_mari_main.png
-        primary_publish_template:
-        primary_scene_item_type: work_file
         primary_tank_type: Mari Scene
         secondary_outputs:
         - description: Publish flattened channels
@@ -529,34 +355,12 @@ engines:
           scene_item_type: layer
           selected: false
           tank_type: UDIM Image
-        template_work:
       tk-multi-workfiles:
-        allow_task_creation: true
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
-        launch_change_work_area_at_startup: false
         location:
           version: v0.7.1
           type: app_store
           name: tk-multi-workfiles
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        sg_entity_type_extra_display_fields: {}
-        sg_entity_type_filters: {}
         sg_entity_types: [Asset]
-        sg_task_filters: []
-        task_extra_display_fields: []
-        template_publish:
-        template_publish_area:
-        template_work:
-        template_work_area:
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2
-    debug_logging: false
     location:
       version: v1.1.4
       type: app_store
@@ -569,19 +373,11 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-maya_scene_operations.py'
         location:
           version: v1.4.3
           type: app_store
           name: tk-multi-breakdown
       tk-multi-loader2:
-        action_mappings:
-          Maya Scene: [reference, import]
-          Photoshop Image: [texture_node]
-          Rendered Image: [texture_node]
-          UDIM Image: [udim_texture_node]
-        actions_hook: '{self}/tk-maya_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -599,26 +395,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -627,7 +408,6 @@ engines:
         primary_display_name: Maya Publish
         primary_icon: icons/publish_maya_main.png
         primary_publish_template: maya_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Maya Scene
         secondary_outputs:
         - description: Publish Alembic data for all geometry in the scene
@@ -656,16 +436,11 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py:{self}/tk-maya_actions.py'
         location:
           version: v1.2.5
           type: app_store
           name: tk-multi-shotgunpanel
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -673,41 +448,14 @@ engines:
         template_snapshot: maya_asset_snapshot
         template_work: maya_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: maya_asset_publish
         template_publish_area: asset_publish_area_maya
         template_work: maya_asset_work
         template_work_area: asset_work_area_maya
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
@@ -718,7 +466,6 @@ engines:
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
     template_project: asset_work_area_maya
-    use_sgtk_as_menu_name: false
   #
   # -------------------------------------------------
   # Motionbuilder
@@ -727,10 +474,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-loader2:
-        action_mappings:
-          Motion Builder FBX: [import]
-        actions_hook: '{self}/tk-motionbuilder_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -748,43 +491,21 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
           name: tk-multi-publish
-        primary_description: Publish and version up the current work file
-        primary_display_name: Current Work File
         primary_icon: icons/publish_motionbuilder_main.png
         primary_publish_template: mobu_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Motion Builder FBX
-        secondary_outputs: []
         template_work: mobu_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -792,40 +513,14 @@ engines:
         template_snapshot: mobu_asset_snapshot
         template_work: mobu_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: mobu_asset_publish
         template_publish_area: asset_publish_area_mobu
         template_work: mobu_asset_work
         template_work_area: asset_work_area_mobu
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
@@ -835,7 +530,6 @@ engines:
     - {app_instance: tk-multi-snapshot, name: Snapshot...}
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
-    use_sgtk_as_menu_name: false
   #
   # -------------------------------------------------
   # Nuke
@@ -844,7 +538,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
         location:
           version: v1.4.3
           type: app_store
@@ -854,8 +547,6 @@ engines:
           Nuke Script: [script_import]
           Rendered Image: [read_node]
           Alembic Cache: [read_node]
-        actions_hook: '{self}/tk-nuke_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -873,26 +564,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -901,7 +577,6 @@ engines:
         primary_display_name: Nuke Publish
         primary_icon: icons/publish_nuke_main.png
         primary_publish_template: nuke_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Nuke Script
         secondary_outputs:
         - description: Copy renders from work area to publish area.
@@ -930,15 +605,8 @@ engines:
           version: v0.3.1
           type: app_store
           name: tk-multi-reviewsubmission
-        movie_height: 540
         movie_path_template: nuke_asset_render_movie
-        movie_width: 1024
-        new_version_status: rev
         slate_logo: icons/review_submit_logo.png
-        store_on_disk: true
-        upload_to_shotgun: true
-        version_number_padding: 3
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-shotgunpanel:
         action_mappings:
@@ -950,16 +618,11 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
         location:
           version: v1.2.5
           type: app_store
           name: tk-multi-shotgunpanel
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -967,39 +630,14 @@ engines:
         template_snapshot: nuke_asset_snapshot
         template_work: nuke_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: nuke_asset_publish
         template_publish_area: asset_publish_area_nuke
         template_work: nuke_asset_work
         template_work_area: asset_work_area_nuke
-        version_compare_ignore_fields: []
       tk-nuke-quickdailies:
         current_scene_template: nuke_asset_work
         height: 768
@@ -1011,8 +649,6 @@ engines:
         post_hooks: [snapshot_history_post_quickdaily]
         sg_version_name_template: nuke_quick_asset_version_name
         width: 1024
-        upload_movie: false
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-nuke-writenode:
         location:
           version: v1.1.2
@@ -1030,9 +666,6 @@ engines:
           tank_type: Rendered Image
           tile_color: []
           promote_write_knobs: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
@@ -1042,12 +675,6 @@ engines:
     - {app_instance: tk-multi-snapshot, name: Snapshot...}
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke Studio
@@ -1056,17 +683,7 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
         display_name: Publish Project
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1075,14 +692,9 @@ engines:
         primary_display_name: Hiero Publish
         primary_icon: icons/publish_hiero_main.png
         primary_publish_template: hiero_project_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Hiero Project
-        secondary_outputs: []
         template_work: hiero_project_work
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1090,33 +702,20 @@ engines:
         template_snapshot: hiero_project_snapshot
         template_work: hiero_project_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
         entities:
         - caption: Projects
           entity_type: Project
           filters: []
           hierarchy: [name]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
         show_my_tasks: false
         template_publish: hiero_project_publish
         template_publish_area: hiero_project_publish_area
         template_work: hiero_project_work
         template_work_area: hiero_project_work_area
-        version_compare_ignore_fields: []
       tk-nuke-quickdailies:
         current_scene_template: nuke_shot_work
         height: 768
@@ -1128,8 +727,6 @@ engines:
         post_hooks: [snapshot_history_post_quickdaily]
         sg_version_name_template: nuke_quick_shot_version_name
         width: 1024
-        upload_movie: false
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-nuke-writenode:
         location:
           version: v1.1.2
@@ -1174,23 +771,14 @@ engines:
           version: v0.3.1
           type: app_store
           name: tk-multi-reviewsubmission
-        movie_height: 540
         movie_path_template: nuke_shot_render_movie
-        movie_width: 1024
-        new_version_status: rev
         slate_logo: icons/review_submit_logo.png
-        store_on_disk: true
-        upload_to_shotgun: true
-        version_number_padding: 3
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
         location:
           name: tk-multi-setframerange
           type: app_store
           version: v0.3.0
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-breakdown:
         hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
         location:
@@ -1203,7 +791,6 @@ engines:
           Rendered Image: [read_node]
           Alembic Cache: [read_node]
         actions_hook: '{self}/tk-nuke_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -1221,14 +808,10 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -1237,19 +820,12 @@ engines:
       requires_selection: true}
     - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
       requires_selection: true}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    favourite_directories: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
   #
   # -------------------------------------------------
   # Photoshop
@@ -1258,11 +834,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-loader2:
-        action_mappings:
-          Photoshop Image: [add_as_a_layer, open_file]
-          Rendered Image: [add_as_a_layer, open_file]
-        actions_hook: '{self}/tk-photoshop_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -1280,26 +851,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1308,15 +864,10 @@ engines:
         primary_display_name: Photoshop Publish
         primary_icon: icons/publish_photoshop_main.png
         primary_publish_template: photoshop_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Photoshop Image
-        secondary_outputs: []
         template_work: photoshop_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1324,40 +875,14 @@ engines:
         template_snapshot: photoshop_asset_snapshot
         template_work: photoshop_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: photoshop_asset_publish
         template_publish_area: asset_publish_area_photoshop
         template_work: photoshop_asset_work
         template_work_area: asset_work_area_photoshop
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.3
       type: app_store
@@ -1389,17 +914,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1408,15 +922,10 @@ engines:
         primary_display_name: Softimage Publish
         primary_icon: icons/publish_softimage_main.png
         primary_publish_template: softimage_asset_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Softimage Scene
-        secondary_outputs: []
         template_work: softimage_asset_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1424,40 +933,14 @@ engines:
         template_snapshot: softimage_asset_snapshot
         template_work: softimage_asset_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           version: v0.7.29
           type: app_store
           name: tk-multi-workfiles2
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: softimage_asset_publish
         template_publish_area: asset_publish_area_softimage
         template_work: softimage_asset_work
         template_work_area: asset_work_area_softimage
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store

--- a/env/includes/app_launchers.yml
+++ b/env/includes/app_launchers.yml
@@ -28,45 +28,31 @@ includes:
 # 3dsmax
 # -------------------------------------------------
 launch_3dsmax:
-  defer_keyword: ''
   engine: tk-3dsmaxplus
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: ''
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: ''
   menu_name: Launch 3dsmax # note: desktop app means we cannot have spaces in app name
-  versions: []
-  windows_args: ''
   windows_path: '@3dsmax_windows'
 #
 # -------------------------------------------------
 # Hiero
 # -------------------------------------------------
 launch_hiero:
-  defer_keyword: ''
   engine: tk-hiero
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_hiero_256.png'
   linux_args: --hiero
   linux_path: '@hiero_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@hiero_mac'
   menu_name: Launch Hiero
-  versions: []
   windows_args: --hiero
   windows_path: '@hiero_win'
 #
@@ -74,137 +60,91 @@ launch_hiero:
 # Houdini
 # -------------------------------------------------
 launch_houdini:
-  defer_keyword: ''
   engine: tk-houdini
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: '@houdini_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@houdini_mac'
   menu_name: Launch Houdini
-  versions: []
-  windows_args: ''
   windows_path: '@houdini_windows'
 #
 # -------------------------------------------------
 # Mari
 # -------------------------------------------------
 launch_mari:
-  defer_keyword: ''
   engine: tk-mari
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: '@mari_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@mari_mac'
   menu_name: Launch Mari
-  versions: []
-  windows_args: ''
   windows_path: '@mari_windows'
 #
 # -------------------------------------------------
 # Maya
 # -------------------------------------------------
 launch_maya:
-  defer_keyword: ''
   engine: tk-maya
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: '@maya_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@maya_mac'
   menu_name: Launch Maya
-  versions: []
-  windows_args: ''
   windows_path: '@maya_windows'
 #
 # -------------------------------------------------
 # Motionbuilder
 # -------------------------------------------------
 launch_motionbuilder:
-  defer_keyword: ''
   engine: tk-motionbuilder
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: ''
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: ''
   menu_name: Launch MotionBuilder
-  versions: []
-  windows_args: ''
   windows_path: '@motionbuilder_windows'
 #
 # -------------------------------------------------
 # Nuke
 # -------------------------------------------------
 launch_nuke:
-  defer_keyword: ''
   engine: tk-nuke
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: '@nuke_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@nuke_mac'
   menu_name: Launch Nuke
-  versions: []
-  windows_args: ''
   windows_path: '@nuke_windows'
 #
 # -------------------------------------------------
 # Nuke Studio
 # -------------------------------------------------
 launch_nukestudio:
-  defer_keyword: ''
   engine: tk-nukestudio
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_nukestudio_256.png'
   linux_args: --studio
   linux_path: '@nukestudio_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@nukestudio_mac'
   menu_name: Launch NukeStudio
-  versions: []
   windows_args: --studio
   windows_path: '@nukestudio_windows'
 #
@@ -212,23 +152,15 @@ launch_nukestudio:
 # Photoshop
 # -------------------------------------------------
 launch_photoshop:
-  defer_keyword: ''
   engine: tk-photoshop
   extra: '@photoshop_extras'
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: ''
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: '@photoshop_mac'
   menu_name: Launch Photoshop
-  versions: []
-  windows_args: ''
   windows_path: '@photoshop_win'
 #
 # -------------------------------------------------
@@ -250,21 +182,13 @@ launch_screeningroom:
 # Softimage
 # -------------------------------------------------
 launch_softimage:
-  defer_keyword: ''
   engine: tk-softimage
   extra: {}
-  hook_app_launch: default
-  hook_before_app_launch: default
-  icon: '{target_engine}/icon_256.png'
-  linux_args: ''
   linux_path: '@softimage_linux'
   location:
     version: v0.7.3
     type: app_store
     name: tk-multi-launchapp
-  mac_args: ''
   mac_path: ''
   menu_name: Launch Softimage
-  versions: []
-  windows_args: ''
   windows_path: '@softimage_windows'

--- a/env/includes/common_apps.yml
+++ b/env/includes/common_apps.yml
@@ -42,36 +42,10 @@ about:
 # and these 'transit' areas can be project, shot, or sequence level.
 #
 workfiles2:
-  allow_task_creation: true
-  create_new_task_hook: '{self}/create_new_task.py'
-  custom_actions_hook: '{self}/custom_actions.py'
-  entities:
-  - caption: Assets
-    entity_type: Task
-    filters:
-    - [entity, type_is, Asset]
-    hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-  - caption: Shots
-    entity_type: Task
-    filters:
-    - [entity, type_is, Shot]
-    hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-  file_extensions: []
-  hook_copy_file: '{self}/copy_file.py'
-  hook_filter_publishes: default
-  hook_filter_work_files: default
-  hook_scene_operation: default
-  launch_at_startup: false
-  location: {name: tk-multi-workfiles2, type: app_store, version: v0.7.29}
-  my_tasks_extra_display_fields: []
-  saveas_default_name: scene
-  saveas_prefer_version_up: false
-  show_my_tasks: true
-  template_publish:
-  template_publish_area:
-  template_work:
-  template_work_area:
-  version_compare_ignore_fields: []
+  location: 
+    name: tk-multi-workfiles2
+    type: app_store
+    version: v0.7.29
 #
 #
 # File Manager that launches at startup.
@@ -79,36 +53,11 @@ workfiles2:
 # For details, see above.
 #
 workfiles2-launch-at-startup:
-  allow_task_creation: true
-  create_new_task_hook: '{self}/create_new_task.py'
-  custom_actions_hook: '{self}/custom_actions.py'
-  entities:
-  - caption: Assets
-    entity_type: Task
-    filters:
-    - [entity, type_is, Asset]
-    hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-  - caption: Shots
-    entity_type: Task
-    filters:
-    - [entity, type_is, Shot]
-    hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-  file_extensions: []
-  hook_copy_file: '{self}/copy_file.py'
-  hook_filter_publishes: default
-  hook_filter_work_files: default
-  hook_scene_operation: default
   launch_at_startup: true
-  location: {name: tk-multi-workfiles2, type: app_store, version: v0.7.29}
-  my_tasks_extra_display_fields: []
-  saveas_default_name: scene
-  saveas_prefer_version_up: false
-  show_my_tasks: true
-  template_publish:
-  template_publish_area:
-  template_work:
-  template_work_area:
-  version_compare_ignore_fields: []
+  location: 
+    name: tk-multi-workfiles2
+    type: app_store
+    version: v0.7.29
 ###############################################################################
 #
 # Framework includes.

--- a/env/project.yml
+++ b/env/project.yml
@@ -35,7 +35,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -49,13 +48,10 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Shotgun Desktop
@@ -73,10 +69,6 @@ engines:
       tk-multi-launchphotoshop: '@launch_photoshop'
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
-    collapse_rules:
-    - {button_label: $app, match: Launch $app, menu_label: None}
-    debug_logging: false
-    default_group: Studio
     groups:
     - matches: ['*Houdini*', '*Mari*', '*Max*', '*Maya*', '*Motion*', '*Nuke*', '*Photoshop*',
         '*Softimage*']
@@ -85,13 +77,10 @@ engines:
       name: Editorial Tools
     - matches: ['*Fla*']
       name: Finishing Tools
-    hook_launch_python: default
     location:
       version: v2.0.10
       type: app_store
       name: tk-desktop
-    show_recents: true
-
   #
   # -------------------------------------------------
   # Hiero
@@ -99,33 +88,18 @@ engines:
   tk-hiero:
     apps:
       tk-hiero-export:
-        audio_published_file_type: Hiero Audio
-        custom_template_fields: []
-        default_task_filter: '[[''step.Step.code'', ''is'', ''Comp'']]'
-        default_task_template: Basic shot template
-        hook_get_extra_publish_data: default
-        hook_get_quicktime_settings: default
-        hook_get_shot: default
-        hook_pre_export: default
-        hook_resolve_custom_strings: default
-        hook_translate_template: default
-        hook_update_version_data: default
-        hook_upload_thumbnail: default
         location:
           version: v0.3.2
           type: app_store
           name: tk-hiero-export
-        nuke_script_published_file_type: Nuke Script
         nuke_script_toolkit_write_nodes:
         - {channel: stereoexr32, name: 'Stereo Exr, 32 bit'}
         - {channel: stereoexr16, name: 'Stereo Exr, 16 bit'}
         - {channel: monodpx, name: Mono Dpx}
-        plate_published_file_type: Hiero Plate
         template_nuke_script_path: nuke_shot_work
         template_plate_path: hiero_plate_path
         template_render_path: hiero_render_path
         template_version: hiero_version
-        hook_post_version_creation: default
       tk-hiero-openinshotgun:
         location:
           name: tk-hiero-openinshotgun
@@ -133,17 +107,7 @@ engines:
           version: v0.3.0
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
         display_name: Publish Project
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -152,14 +116,9 @@ engines:
         primary_display_name: Hiero Publish
         primary_icon: icons/publish_hiero_main.png
         primary_publish_template: hiero_project_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Hiero Project
-        secondary_outputs: []
         template_work: hiero_project_work
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -167,33 +126,14 @@ engines:
         template_snapshot: hiero_project_snapshot
         template_work: hiero_project_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Projects
-          entity_type: Project
-          filters: []
-          hierarchy: [name]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: false
         template_publish: hiero_project_publish
         template_publish_area: hiero_project_publish_area
         template_work: hiero_project_work
         template_work_area: hiero_project_work_area
-        version_compare_ignore_fields: []
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -202,11 +142,6 @@ engines:
       requires_selection: true}
     - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
       requires_selection: true}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    favourite_directories: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
     location:
       version: v0.5.6
       type: app_store
@@ -232,10 +167,6 @@ engines:
       version: v1.0.1
       type: app_store
       name: tk-houdini
-    enable_sg_shelf: true
-    debug_logging: false
-    enable_sg_menu: true
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Mari
@@ -244,32 +175,11 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-workfiles:
-        allow_task_creation: true
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
-        launch_change_work_area_at_startup: false
         location:
           version: v0.7.1
           type: app_store
           name: tk-multi-workfiles
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        sg_entity_type_extra_display_fields: {}
-        sg_entity_type_filters: {}
         sg_entity_types: [Asset]
-        sg_task_filters: []
-        task_extra_display_fields: []
-        template_publish:
-        template_publish_area:
-        template_work:
-        template_work_area:
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2
-    debug_logging: false
     location:
       version: v1.1.4
       type: app_store
@@ -283,17 +193,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2-launch-at-startup'
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
       name: tk-maya
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Motionbuilder
@@ -303,7 +208,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
@@ -311,8 +215,6 @@ engines:
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
     template_project:
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke
@@ -322,20 +224,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
   #
   # -------------------------------------------------
   # Nuke Studio
@@ -343,33 +237,18 @@ engines:
   tk-nukestudio:
     apps:
       tk-hiero-export:
-        audio_published_file_type: Hiero Audio
-        custom_template_fields: []
-        default_task_filter: '[[''step.Step.code'', ''is'', ''Comp'']]'
-        default_task_template: Basic shot template
-        hook_get_extra_publish_data: default
-        hook_get_quicktime_settings: default
-        hook_get_shot: default
-        hook_pre_export: default
-        hook_resolve_custom_strings: default
-        hook_translate_template: default
-        hook_update_version_data: default
-        hook_upload_thumbnail: default
         location:
           version: v0.3.2
           type: app_store
           name: tk-hiero-export
-        nuke_script_published_file_type: Nuke Script
         nuke_script_toolkit_write_nodes:
         - {channel: stereoexr32, name: 'Stereo Exr, 32 bit'}
         - {channel: stereoexr16, name: 'Stereo Exr, 16 bit'}
         - {channel: monodpx, name: Mono Dpx}
-        plate_published_file_type: Hiero Plate
         template_nuke_script_path: nuke_shot_work
         template_plate_path: hiero_plate_path
         template_render_path: hiero_render_path
         template_version: hiero_version
-        hook_post_version_creation: default
       tk-hiero-openinshotgun:
         location:
           name: tk-hiero-openinshotgun
@@ -377,17 +256,7 @@ engines:
           version: v0.3.0
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
         display_name: Publish Project
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -396,14 +265,9 @@ engines:
         primary_display_name: Hiero Publish
         primary_icon: icons/publish_hiero_main.png
         primary_publish_template: hiero_project_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Hiero Project
-        secondary_outputs: []
         template_work: hiero_project_work
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -411,33 +275,20 @@ engines:
         template_snapshot: hiero_project_snapshot
         template_work: hiero_project_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
         entities:
         - caption: Projects
           entity_type: Project
           filters: []
           hierarchy: [name]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
         show_my_tasks: false
         template_publish: hiero_project_publish
         template_publish_area: hiero_project_publish_area
         template_work: hiero_project_work
         template_work_area: hiero_project_work_area
-        version_compare_ignore_fields: []
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -446,11 +297,6 @@ engines:
       requires_selection: true}
     - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
       requires_selection: true}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    favourite_directories: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
     location:
       version: v0.5.6
       type: app_store
@@ -472,7 +318,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.3
       type: app_store
@@ -508,14 +353,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store
       name: tk-softimage
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
 #
 ###############################################################################
 #

--- a/env/sequence.yml
+++ b/env/sequence.yml
@@ -41,7 +41,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -55,13 +54,10 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Houdini
@@ -75,10 +71,6 @@ engines:
       version: v1.0.1
       type: app_store
       name: tk-houdini
-    enable_sg_shelf: true
-    debug_logging: false
-    enable_sg_menu: true
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Maya
@@ -88,17 +80,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2-launch-at-startup'
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
       name: tk-maya
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Motionbuilder
@@ -108,15 +95,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
       name: tk-motionbuilder
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke
@@ -126,21 +110,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Shell (tank command)
@@ -169,14 +144,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store
       name: tk-softimage
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
 #
 ###############################################################################
 #

--- a/env/shot.yml
+++ b/env/shot.yml
@@ -40,7 +40,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -54,13 +53,10 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # Houdini
@@ -74,10 +70,6 @@ engines:
       version: v1.0.1
       type: app_store
       name: tk-houdini
-    enable_sg_shelf: true
-    debug_logging: false
-    enable_sg_menu: true
-    menu_favourites: []
   #
   # -------------------------------------------------
   # maya
@@ -87,17 +79,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2-launch-at-startup'
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
       name: tk-maya
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # motionbuilder
@@ -107,15 +94,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
       name: tk-motionbuilder
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # nuke
@@ -125,20 +109,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
   #
   # -------------------------------------------------
   # Photoshop
@@ -148,7 +124,6 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.3
       type: app_store
@@ -181,14 +156,12 @@ engines:
       tk-multi-about: '@about'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-workfiles2: '@workfiles2'
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store
       name: tk-softimage
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    template_project:
 #
 ###############################################################################
 #

--- a/env/shot_step.yml
+++ b/env/shot_step.yml
@@ -34,8 +34,6 @@ engines:
       tk-multi-loader2:
         action_mappings:
           3dsmax Scene: [import]
-        actions_hook: '{self}/tk-3dsmax_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -53,26 +51,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -81,9 +64,7 @@ engines:
         primary_display_name: 3ds Max Publish
         primary_icon: icons/publish_3dsmax_main.png
         primary_publish_template: max_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: 3dsmax Scene
-        secondary_outputs: []
         template_work: max_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
@@ -91,12 +72,7 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -104,40 +80,14 @@ engines:
         template_snapshot: max_shot_snapshot
         template_work: max_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: max_shot_publish
         template_publish_area: shot_publish_area_max
         template_work: max_shot_work
         template_work_area: shot_work_area_max
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.9
       type: app_store
@@ -153,48 +103,11 @@ engines:
         action_mappings:
           3dsmax Scene: [import, reference]
           Alembic Cache: [import]
-        actions_hook: '{self}/tk-3dsmaxplus_actions.py'
-        download_thumbnails: true
-        entities:
-        - caption: Assets
-          entity_type: Asset
-          filters:
-          - [project, is, '{context.project}']
-          hierarchy: [sg_asset_type, code]
-          publish_filters: []
-        - caption: Shots
-          entity_type: Shot
-          filters:
-          - [project, is, '{context.project}']
-          hierarchy: [sg_sequence, code]
-          publish_filters: []
-        - caption: My Tasks
-          entity_type: Task
-          filters:
-          - [task_assignees, is, '{context.user}']
-          - [project, is, '{context.project}']
-          hierarchy: [entity, content]
-          publish_filters: []
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -203,9 +116,7 @@ engines:
         primary_display_name: 3ds Max Publish
         primary_icon: icons/publish_3dsmax_main.png
         primary_publish_template: max_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: 3dsmax Scene
-        secondary_outputs: []
         template_work: max_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
@@ -213,12 +124,7 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -226,46 +132,18 @@ engines:
         template_snapshot: max_shot_snapshot
         template_work: max_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: max_shot_publish
         template_publish_area: shot_publish_area_max
         template_work: max_shot_work
         template_work_area: shot_work_area_max
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2017
-    debug_logging: false
     location:
       version: v0.1.14
       type: app_store
       name: tk-3dsmaxplus
-    menu_favourites: []
   #
   # -------------------------------------------------
   # houdini
@@ -274,17 +152,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -293,7 +160,6 @@ engines:
         primary_display_name: Scene File Publish
         primary_icon: icons/publish_houdini_main.png
         primary_publish_template: houdini_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Houdini Scene
         secondary_outputs:
         - description: Publish Alembic Cache data for the model
@@ -327,12 +193,7 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -340,39 +201,14 @@ engines:
         template_snapshot: houdini_shot_snapshot
         template_work: houdini_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: houdini_shot_publish
         template_publish_area: shot_publish_area_houdini
         template_work: houdini_shot_work
         template_work_area: shot_work_area_houdini
-        version_compare_ignore_fields: []
       tk-multi-shotgunpanel:
         location:
           version: v1.2.5
@@ -382,8 +218,6 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py'
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-houdini-alembicnode:
         location:
           version: v0.2.5
@@ -414,8 +248,6 @@ engines:
       tk-multi-loader2:
         action_mappings:
           Alembic Cache: [import]
-        actions_hook: '{self}/tk-houdini_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -433,23 +265,15 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-houdini_scene_operations.py'
         location:
           name: tk-multi-breakdown
           type: app_store
           version: v1.4.3
-    debug_logging: false
-    enable_sg_shelf: true
-    enable_sg_menu: true
     location:
       version: v1.0.1
       type: app_store
@@ -467,7 +291,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-maya_scene_operations.py'
         location:
           version: v1.4.3
           type: app_store
@@ -477,8 +300,6 @@ engines:
           Maya Scene: [reference, import]
           Photoshop Image: [texture_node]
           Rendered Image: [texture_node]
-        actions_hook: '{self}/tk-maya_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -496,26 +317,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -524,9 +330,7 @@ engines:
         primary_display_name: Maya Publish
         primary_icon: icons/publish_maya_main.png
         primary_publish_template: maya_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Maya Scene
-        secondary_outputs: []
         template_work: maya_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
@@ -534,8 +338,6 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-shotgunpanel:
         action_mappings:
           PublishedFile:
@@ -550,16 +352,11 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py:{self}/tk-maya_actions.py'
         location:
           version: v1.2.5
           type: app_store
           name: tk-multi-shotgunpanel
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -567,41 +364,14 @@ engines:
         template_snapshot: maya_shot_snapshot
         template_work: maya_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: maya_shot_publish
         template_publish_area: shot_publish_area_maya
         template_work: maya_shot_work
         template_work_area: shot_work_area_maya
-        version_compare_ignore_fields: []
-    compatibility_dialog_min_version: 2015
-    debug_logging: false
     location:
       version: v0.5.5
       type: app_store
@@ -612,8 +382,6 @@ engines:
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
     template_project: shot_work_area_maya
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # motionbuilder
@@ -622,10 +390,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-loader2:
-        action_mappings:
-          Motion Builder FBX: [import]
-        actions_hook: '{self}/tk-motionbuilder_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -643,37 +407,18 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
           name: tk-multi-publish
-        primary_description: Publish and version up the current work file
-        primary_display_name: Current Work File
         primary_icon: icons/publish_motionbuilder_main.png
         primary_publish_template: mobu_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Motion Builder FBX
-        secondary_outputs: []
         template_work: mobu_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
@@ -681,12 +426,7 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -694,40 +434,14 @@ engines:
         template_snapshot: mobu_shot_snapshot
         template_work: mobu_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: mobu_shot_publish
         template_publish_area: shot_publish_area_mobu
         template_work: mobu_shot_work
         template_work_area: shot_work_area_mobu
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.1
       type: app_store
@@ -737,8 +451,6 @@ engines:
     - {app_instance: tk-multi-snapshot, name: Snapshot...}
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke
@@ -747,7 +459,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-breakdown:
-        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
         location:
           version: v1.4.3
           type: app_store
@@ -757,8 +468,6 @@ engines:
           Nuke Script: [script_import]
           Rendered Image: [read_node]
           Alembic Cache: [read_node]
-        actions_hook: '{self}/tk-nuke_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -776,26 +485,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -804,7 +498,6 @@ engines:
         primary_display_name: Nuke Publish
         primary_icon: icons/publish_nuke_main.png
         primary_publish_template: nuke_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Nuke Script
         secondary_outputs:
         - description: Copy renders from work area to publish area.
@@ -833,23 +526,14 @@ engines:
           version: v0.3.1
           type: app_store
           name: tk-multi-reviewsubmission
-        movie_height: 540
         movie_path_template: nuke_shot_render_movie
-        movie_width: 1024
-        new_version_status: rev
         slate_logo: icons/review_submit_logo.png
-        store_on_disk: true
-        upload_to_shotgun: true
-        version_number_padding: 3
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
         location:
           name: tk-multi-setframerange
           type: app_store
           version: v0.3.0
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-shotgunpanel:
         action_mappings:
           PublishedFile:
@@ -860,16 +544,11 @@ engines:
           Task:
           - actions: [assign_task, task_to_ip]
             filters: {}
-        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
         location:
           version: v1.2.5
           type: app_store
           name: tk-multi-shotgunpanel
-        shotgun_fields_hook: '{self}/shotgun_fields.py'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -877,39 +556,14 @@ engines:
         template_snapshot: nuke_shot_snapshot
         template_work: nuke_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: nuke_shot_publish
         template_publish_area: shot_publish_area_nuke
         template_work: nuke_shot_work
         template_work_area: shot_work_area_nuke
-        version_compare_ignore_fields: []
       tk-nuke-quickdailies:
         current_scene_template: nuke_shot_work
         height: 768
@@ -921,8 +575,6 @@ engines:
         post_hooks: [snapshot_history_post_quickdaily]
         sg_version_name_template: nuke_quick_shot_version_name
         width: 1024
-        upload_movie: false
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-nuke-writenode:
         location:
           version: v1.1.2
@@ -962,9 +614,6 @@ engines:
           settings: {}
           tank_type: Rendered Image
           tile_color: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
-    favourite_directories: []
     location:
       version: v0.5.6
       type: app_store
@@ -974,12 +623,6 @@ engines:
     - {app_instance: tk-multi-snapshot, name: Snapshot...}
     - {app_instance: tk-multi-workfiles2, name: File Save...}
     - {app_instance: tk-multi-publish, name: Publish...}
-    bin_context_menu: []
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-
   #
   # -------------------------------------------------
   # Nuke Studio
@@ -988,17 +631,7 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
         display_name: Publish Project
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1007,14 +640,9 @@ engines:
         primary_display_name: Hiero Publish
         primary_icon: icons/publish_hiero_main.png
         primary_publish_template: hiero_project_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Hiero Project
-        secondary_outputs: []
         template_work: hiero_project_work
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1022,33 +650,20 @@ engines:
         template_snapshot: hiero_project_snapshot
         template_work: hiero_project_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
         entities:
         - caption: Projects
           entity_type: Project
           filters: []
           hierarchy: [name]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
         show_my_tasks: false
         template_publish: hiero_project_publish
         template_publish_area: hiero_project_publish_area
         template_work: hiero_project_work
         template_work_area: hiero_project_work_area
-        version_compare_ignore_fields: []
       tk-nuke-quickdailies:
         current_scene_template: nuke_shot_work
         height: 768
@@ -1060,8 +675,6 @@ engines:
         post_hooks: [snapshot_history_post_quickdaily]
         sg_version_name_template: nuke_quick_shot_version_name
         width: 1024
-        upload_movie: false
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-nuke-writenode:
         location:
           version: v1.1.2
@@ -1106,23 +719,14 @@ engines:
           version: v0.3.1
           type: app_store
           name: tk-multi-reviewsubmission
-        movie_height: 540
         movie_path_template: nuke_shot_render_movie
-        movie_width: 1024
-        new_version_status: rev
         slate_logo: icons/review_submit_logo.png
-        store_on_disk: true
-        upload_to_shotgun: true
-        version_number_padding: 3
-        codec_settings_hook: '{self}/codec_settings.py'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
         location:
           name: tk-multi-setframerange
           type: app_store
           version: v0.3.0
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-breakdown:
         hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
         location:
@@ -1135,7 +739,6 @@ engines:
           Rendered Image: [read_node]
           Alembic Cache: [read_node]
         actions_hook: '{self}/tk-nuke_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -1153,14 +756,10 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
     bin_context_menu:
     - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
       requires_selection: true}
@@ -1169,19 +768,12 @@ engines:
       requires_selection: true}
     - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
       requires_selection: true}
-    project_favourite_name: Shotgun Current Project
-    use_sgtk_as_menu_name: false
-    favourite_directories: []
-    compatibility_dialog_min_version: 10
-    debug_logging: false
     location:
       version: v0.5.6
       type: app_store
       name: tk-nuke
     menu_favourites:
     - {app_instance: tk-multi-workfiles2, name: File Open...}
-    spreadsheet_context_menu: []
-    timeline_context_menu: []
   #
   # -------------------------------------------------
   # photoshop
@@ -1190,11 +782,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-loader2:
-        action_mappings:
-          Photoshop Image: [add_as_a_layer, open_file]
-          Rendered Image: [add_as_a_layer, open_file]
-        actions_hook: '{self}/tk-photoshop_actions.py'
-        download_thumbnails: true
         entities:
         - caption: Assets
           entity_type: Asset
@@ -1212,26 +799,11 @@ engines:
           - [task_assignees, is, '{context.user}']
           - [project, is, '{context.project}']
           hierarchy: [entity, content]
-        filter_publishes_hook: '{self}/filter_publishes.py'
         location:
           version: v1.11.1
           type: app_store
           name: tk-multi-loader2
-        menu_name: Load
-        publish_filters: []
-        title_name: Loader
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1240,15 +812,10 @@ engines:
         primary_display_name: Photoshop Publish
         primary_icon: icons/publish_photoshop_main.png
         primary_publish_template: photoshop_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Photoshop Image
-        secondary_outputs: []
         template_work: photoshop_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1256,40 +823,14 @@ engines:
         template_snapshot: photoshop_shot_snapshot
         template_work: photoshop_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: photoshop_shot_publish
         template_publish_area: shot_publish_area_photoshop
         template_work: photoshop_shot_work
         template_work_area: shot_work_area_photoshop
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.3
       type: app_store
@@ -1322,17 +863,6 @@ engines:
     apps:
       tk-multi-about: '@about'
       tk-multi-publish:
-        allow_taskless_publishes: true
-        display_name: Publish
-        expand_single_items: false
-        hook_copy_file: default
-        hook_post_publish: default
-        hook_primary_pre_publish: default
-        hook_primary_publish: default
-        hook_scan_scene: default
-        hook_secondary_pre_publish: default
-        hook_secondary_publish: default
-        hook_thumbnail: default
         location:
           version: v0.8.7
           type: app_store
@@ -1341,9 +871,7 @@ engines:
         primary_display_name: Softimage Publish
         primary_icon: icons/publish_softimage_main.png
         primary_publish_template: softimage_shot_publish
-        primary_scene_item_type: work_file
         primary_tank_type: Softimage Scene
-        secondary_outputs: []
         template_work: softimage_shot_work
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-multi-setframerange:
@@ -1351,12 +879,7 @@ engines:
           version: v0.3.0
           type: app_store
           name: tk-multi-setframerange
-        sg_in_frame_field: sg_cut_in
-        sg_out_frame_field: sg_cut_out
       tk-multi-snapshot:
-        hook_copy_file: default
-        hook_scene_operation: default
-        hook_thumbnail: default
         location:
           version: v0.6.1
           type: app_store
@@ -1364,40 +887,14 @@ engines:
         template_snapshot: softimage_shot_snapshot
         template_work: softimage_shot_work
       tk-multi-workfiles2:
-        allow_task_creation: true
-        create_new_task_hook: default
-        custom_actions_hook: default
-        entities:
-        - caption: Assets
-          entity_type: Task
-          filters:
-          - [entity, type_is, Asset]
-          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
-        - caption: Shots
-          entity_type: Task
-          filters:
-          - [entity, type_is, Shot]
-          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
-        file_extensions: []
-        hook_copy_file: default
-        hook_filter_publishes: default
-        hook_filter_work_files: default
-        hook_scene_operation: default
-        launch_at_startup: false
         location:
           name: tk-multi-workfiles2
           type: app_store
           version: v0.7.29
-        my_tasks_extra_display_fields: []
-        saveas_default_name: scene
-        saveas_prefer_version_up: false
-        show_my_tasks: true
         template_publish: softimage_shot_publish
         template_publish_area: shot_publish_area_softimage
         template_work: softimage_shot_work
         template_work_area: shot_work_area_softimage
-        version_compare_ignore_fields: []
-    debug_logging: false
     location:
       version: v0.3.2
       type: app_store

--- a/env/shotgun_asset.yml
+++ b/env/shotgun_asset.yml
@@ -39,20 +39,15 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-folders:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-folders
           type: app_store
           version: v0.1.5
       tk-shotgun-launchfolder:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-launchfolder
           type: app_store
           version: v0.1.5
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -67,4 +62,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_project.yml
+++ b/env/shotgun_project.yml
@@ -42,13 +42,10 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-launchfolder:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-launchfolder
           type: app_store
           version: v0.1.5
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -62,4 +59,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_publishedfile.yml
+++ b/env/shotgun_publishedfile.yml
@@ -40,9 +40,6 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-launchpublish:
-        deny_permissions: []
-        deny_platforms: []
-        hook_launch_publish: default
         location:
           name: tk-shotgun-launchpublish
           type: app_store
@@ -51,7 +48,6 @@ engines:
         viewer_path_linux: '@rv_linux'
         viewer_path_mac: '@rv_mac'
         viewer_path_windows: '@rv_win'
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -65,4 +61,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_sequence.yml
+++ b/env/shotgun_sequence.yml
@@ -10,7 +10,7 @@
 #
 
 description: This environment controls what items should be shown on the menu in Shotgun
-             for shots.
+  for shots. 
 
 #################################################################################################
 # include common definitions for all the launchers that are used to start maya, nuke etc.
@@ -39,20 +39,15 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-folders:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-folders
           type: app_store
           version: v0.1.5
       tk-shotgun-launchfolder:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-launchfolder
           type: app_store
           version: v0.1.5
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -66,4 +61,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_shot.yml
+++ b/env/shotgun_shot.yml
@@ -10,7 +10,7 @@
 #
 
 description: This environment controls what items should be shown on the menu in Shotgun
-             for shots.
+  for shots. 
 
 #################################################################################################
 # include common definitions for all the launchers that are used to start maya, nuke etc.
@@ -39,20 +39,15 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-folders:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-folders
           type: app_store
           version: v0.1.5
       tk-shotgun-launchfolder:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-launchfolder
           type: app_store
           version: v0.1.5
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -67,4 +62,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_tankpublishedfile.yml
+++ b/env/shotgun_tankpublishedfile.yml
@@ -10,7 +10,7 @@
 #
 
 description: This environment controls what items should be shown on the menu in Shotgun
-             for publishes.
+  for publishes.
 
 #################################################################################################
 # include common definitions for all the launchers that are used to start maya, nuke etc.
@@ -41,9 +41,6 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-launchpublish:
-        deny_permissions: []
-        deny_platforms: []
-        hook_launch_publish: default
         location:
           name: tk-shotgun-launchpublish
           type: app_store
@@ -52,7 +49,6 @@ engines:
         viewer_path_linux: '@rv_linux'
         viewer_path_mac: '@rv_mac'
         viewer_path_windows: '@rv_win'
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -67,4 +63,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_task.yml
+++ b/env/shotgun_task.yml
@@ -10,7 +10,7 @@
 #
 
 description: This environment controls what items should be shown on the menu in Shotgun
-             for tasks.
+  for tasks. 
 
 #################################################################################################
 # include common definitions for all the launchers that are used to start maya, nuke etc.
@@ -40,13 +40,10 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-launchfolder:
-        deny_permissions: []
-        deny_platforms: []
         location:
           name: tk-shotgun-launchfolder
           type: app_store
           version: v0.1.5
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -61,4 +58,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:

--- a/env/shotgun_version.yml
+++ b/env/shotgun_version.yml
@@ -10,7 +10,7 @@
 #
 
 description: This environment controls what items should be shown on the menu in Shotgun
-             for publishes.
+  for publishes.
 
 #################################################################################################
 # include common definitions for all the launchers that are used to start maya, nuke etc.
@@ -40,9 +40,6 @@ engines:
       tk-multi-launchsoftimage: '@launch_softimage'
       tk-multi-screeningroom: '@launch_screeningroom'
       tk-shotgun-launchpublish:
-        deny_permissions: []
-        deny_platforms: []
-        hook_launch_publish: default
         location:
           name: tk-shotgun-launchpublish
           type: app_store
@@ -51,7 +48,6 @@ engines:
         viewer_path_linux: '@rv_linux'
         viewer_path_mac: '@rv_mac'
         viewer_path_windows: '@rv_win'
-    debug_logging: false
     location:
       name: tk-shotgun
       type: app_store
@@ -66,4 +62,4 @@ engines:
 # common functionality for building UIs and communicating with Shotgun.
 # Frameworks are automatically installed when apps are installed and udpated.
 #
-frameworks: null
+frameworks:


### PR DESCRIPTION
This change is in conjunction with develop/0.18 branch of core which supports sparse config files. The changes to these files are simply to remove settings that match the default values specified in the corresponding bundle's manifest file.

These changes were generated, for the most part, using the ./tank validate --dump-sparse action. The files in the includes directory were made sparse by hand since the action does not handle sparsifying included files.